### PR TITLE
Remove app subdirectory from unit test component gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ build/*
 *.out.cpp
 *.out.h
 
-src/app/unit_test_component/*
+src/unit_test_component/*


### PR DESCRIPTION
Got changed in b90c5824297c437bf05157f45d7f05eb8a6c1995, but `.gitignore` was never updated to reflect the change.