### PR TITLE
Add Wshadow flag to gcc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@
 if (MSVC)
     add_compile_options(/W4 /WX)
 else()
-    add_compile_options(-Wall -Wextra -pedantic -Werror)
+    add_compile_options(-Wall -Wextra -Wshadow -pedantic -Werror)
 endif()
 
 


### PR DESCRIPTION
Adds the -Wshadow flag to gcc. `/W4` in MSVC has it active.